### PR TITLE
fix: responsiveness of navbar (max-width: 850px)

### DIFF
--- a/docs/demo/css/style.css
+++ b/docs/demo/css/style.css
@@ -453,8 +453,16 @@ a:active {
 }
 
 @media screen and (max-width: 850px) {
+	.settings {
+		top: 40px;
+	}
 	.tower-navigation {
+		display: flex;
+		align-items: center;
 		height: 100px;
+	}
+	.tower-logo-container {
+		border-style: none;
 	}
 	.tower-logo-container.tower-nav-min {
 		-webkit-transform: translate3d(0, 0, 0);
@@ -466,12 +474,6 @@ a:active {
 	}
 	.tower-logo-container.tower-nav-min+.tower-logo-hidden {
 		display: none;
-	}
-	.tower-logo-container {
-		display: block;
-		float: none;
-		width: 100%;
-		border-bottom: 1px solid #F2F2F2;
 	}
 	.tower-sidebar {
 		top: 100px;


### PR DESCRIPTION
Closes #2 

Navbar breaks when screen size is less than 850px. This PR corrects it.

Before:
![before](https://user-images.githubusercontent.com/10570968/85206350-1d0e2800-b33f-11ea-990e-841b9bd15532.png)

After:
![after](https://user-images.githubusercontent.com/10570968/85206352-226b7280-b33f-11ea-8351-8a001d39991c.png)
  