### PR TITLE
Fix navbar responsiveness and new feature theme switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,164 @@
+{
+	"name": "jif-dashboard",
+	"version": "1.3.6",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "jif-dashboard",
+			"version": "1.3.6",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"draggabilly": "^2.1.1",
+				"packery": "^2.1.1",
+				"underscore": "^1.8.3"
+			}
+		},
+		"node_modules/desandro-matches-selector": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
+			"integrity": "sha512-+1q0nXhdzg1IpIJdMKalUwvvskeKnYyEe3shPRwedNcWtnhEKT3ZxvFjzywHDeGcKViIxTCAoOYQWP1qD7VNyg=="
+		},
+		"node_modules/draggabilly": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/draggabilly/-/draggabilly-2.4.1.tgz",
+			"integrity": "sha512-HHHLPEPZqRXIDQDFRFdK7RONZausNlJ4WkA73ST7Z6O2HPWttxFHVwHo8nccuDLzXWwiVKRVuc6fTkW+CQA++A==",
+			"dependencies": {
+				"get-size": "^2.0.2",
+				"unidragger": "^2.4.0"
+			}
+		},
+		"node_modules/ev-emitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
+			"integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
+		},
+		"node_modules/fizzy-ui-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.7.tgz",
+			"integrity": "sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==",
+			"dependencies": {
+				"desandro-matches-selector": "^2.0.0"
+			}
+		},
+		"node_modules/get-size": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.3.tgz",
+			"integrity": "sha512-lXNzT/h/dTjTxRbm9BXb+SGxxzkm97h/PCIKtlN/CBCxxmkkIVV21udumMS93MuVTDX583gqc94v3RjuHmI+2Q=="
+		},
+		"node_modules/outlayer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.1.tgz",
+			"integrity": "sha512-+GplXsCQ3VrbGujAeHEzP9SXsBmJxzn/YdDSQZL0xqBmAWBmortu2Y9Gwdp9J0bgDQ8/YNIPMoBM13nTwZfAhw==",
+			"dependencies": {
+				"ev-emitter": "^1.0.0",
+				"fizzy-ui-utils": "^2.0.0",
+				"get-size": "^2.0.2"
+			}
+		},
+		"node_modules/packery": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/packery/-/packery-2.1.2.tgz",
+			"integrity": "sha512-Coc+8Atz03c0iu1RK0PZIJMKcKrE4i9Z8UBBywqz7Dhy40mMPM5wMQfqO9P2eqFP+lxKjGMTHgRAwjBQc+AQ5w==",
+			"dependencies": {
+				"get-size": "^2.0.2",
+				"outlayer": "^2.0.0"
+			}
+		},
+		"node_modules/underscore": {
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+		},
+		"node_modules/unidragger": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/unidragger/-/unidragger-2.4.0.tgz",
+			"integrity": "sha512-MueZK2oXuGE6OAlGKIrSXK2zCq+8yb1QUZgqyTDCSJzvwYL0g2Llrad+TtoQTYxtFnNyxxSw0IMnKNIgEMia1w==",
+			"dependencies": {
+				"unipointer": "^2.4.0"
+			}
+		},
+		"node_modules/unipointer": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/unipointer/-/unipointer-2.4.0.tgz",
+			"integrity": "sha512-VjzDLPjGK7aYpQKH7bnDZS8X4axF5AFU/LQi+NQe1oyEHfaz6lWKhaQ7n4o7vJ1iJ4i2T0quCIfrQM139p05Sw==",
+			"dependencies": {
+				"ev-emitter": "^1.0.1"
+			}
+		}
+	},
+	"dependencies": {
+		"desandro-matches-selector": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
+			"integrity": "sha512-+1q0nXhdzg1IpIJdMKalUwvvskeKnYyEe3shPRwedNcWtnhEKT3ZxvFjzywHDeGcKViIxTCAoOYQWP1qD7VNyg=="
+		},
+		"draggabilly": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/draggabilly/-/draggabilly-2.4.1.tgz",
+			"integrity": "sha512-HHHLPEPZqRXIDQDFRFdK7RONZausNlJ4WkA73ST7Z6O2HPWttxFHVwHo8nccuDLzXWwiVKRVuc6fTkW+CQA++A==",
+			"requires": {
+				"get-size": "^2.0.2",
+				"unidragger": "^2.4.0"
+			}
+		},
+		"ev-emitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
+			"integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
+		},
+		"fizzy-ui-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.7.tgz",
+			"integrity": "sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==",
+			"requires": {
+				"desandro-matches-selector": "^2.0.0"
+			}
+		},
+		"get-size": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.3.tgz",
+			"integrity": "sha512-lXNzT/h/dTjTxRbm9BXb+SGxxzkm97h/PCIKtlN/CBCxxmkkIVV21udumMS93MuVTDX583gqc94v3RjuHmI+2Q=="
+		},
+		"outlayer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.1.tgz",
+			"integrity": "sha512-+GplXsCQ3VrbGujAeHEzP9SXsBmJxzn/YdDSQZL0xqBmAWBmortu2Y9Gwdp9J0bgDQ8/YNIPMoBM13nTwZfAhw==",
+			"requires": {
+				"ev-emitter": "^1.0.0",
+				"fizzy-ui-utils": "^2.0.0",
+				"get-size": "^2.0.2"
+			}
+		},
+		"packery": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/packery/-/packery-2.1.2.tgz",
+			"integrity": "sha512-Coc+8Atz03c0iu1RK0PZIJMKcKrE4i9Z8UBBywqz7Dhy40mMPM5wMQfqO9P2eqFP+lxKjGMTHgRAwjBQc+AQ5w==",
+			"requires": {
+				"get-size": "^2.0.2",
+				"outlayer": "^2.0.0"
+			}
+		},
+		"underscore": {
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+		},
+		"unidragger": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/unidragger/-/unidragger-2.4.0.tgz",
+			"integrity": "sha512-MueZK2oXuGE6OAlGKIrSXK2zCq+8yb1QUZgqyTDCSJzvwYL0g2Llrad+TtoQTYxtFnNyxxSw0IMnKNIgEMia1w==",
+			"requires": {
+				"unipointer": "^2.4.0"
+			}
+		},
+		"unipointer": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/unipointer/-/unipointer-2.4.0.tgz",
+			"integrity": "sha512-VjzDLPjGK7aYpQKH7bnDZS8X4axF5AFU/LQi+NQe1oyEHfaz6lWKhaQ7n4o7vJ1iJ4i2T0quCIfrQM139p05Sw==",
+			"requires": {
+				"ev-emitter": "^1.0.1"
+			}
+		}
+	}
+}

--- a/samples/cakeshop/.vscode/settings.json
+++ b/samples/cakeshop/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/samples/cakeshop/components/Navbar.html
+++ b/samples/cakeshop/components/Navbar.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Navbar</title>
+    <link rel="stylesheet" type="text/css" href="/css/navbar.css">
+    <link rel="stylesheet" type="text/css" href="/css/font-awesome.min.css">
+   
+    <script>
+        function toggleMenu() {
+            var menu = document.getElementById('popupMenu');
+            menu.classList.toggle('show');
+          }
+        
+        function refreshPage() {
+            location.reload();
+        }
+
+    </script>
+</head>
+<body>
+        <header> 
+            <div class="navbar">
+                <div class="navbar-logo">
+                    Sample // Dashboard
+                </div>
+               
+                <div class="container">
+                    <button class="icon-button" onclick="toggleMenu()">
+                      <i class="fa fa-cog dropdown-toggle"></i>
+                    </button>
+                    <div class="popup-menu" id="popupMenu">
+                        <ul>
+							<li  href="#"><h4>Settings</h4></li>
+							<li id="reset" href="#" ><a  href="#">Reset Layouts</a></li>  
+						</ul>	
+                    </div>
+                  </div>
+                
+            </div>
+        </header>
+</body>
+</html>

--- a/samples/cakeshop/css/navbar.css
+++ b/samples/cakeshop/css/navbar.css
@@ -1,0 +1,116 @@
+.navbar {
+    width: 100vw;
+    background-color: red;
+    height: 50px;
+    margin: 0%;
+    padding: 0%;
+    font-family: 'Roboto Condensed', "Helvetica Neue", Helvetica, Arial, sans-serif;
+    box-shadow: 0 0px 9px 4px rgba(0, 0, 0, 0.1), 0 -5px 2px 2px
+		rgba(0, 0, 0, 0.1);
+	background: white;
+	display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+}
+
+.navbar-logo {
+    font-weight: 900;
+    margin: 0px 30px;
+    font-size: 22px;
+}
+
+.container {
+    position: relative;
+    margin: 0px 30px;
+    width:30px;
+  }
+  
+  .icon-button {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+   
+  }
+  
+  .popup-menu {
+    position: absolute;
+    top: 40px;
+    right: 0;
+    box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;
+    background: white;
+    border-radius: 5px;
+  
+    display: none;
+    width: max-content;
+    padding: 20px 15px;
+    /* height: fit-content; */
+    border-top: 3px solid black;
+
+  }
+
+  .popup-menu::after {
+    content: "";
+    position: absolute;
+    display: block;
+    top: -10px;
+    right: 10px;
+    width: 0px;
+    height: 0px;
+    /* background-color: rgb(0, 0, 0); */
+    /* transform: rotate(45deg); */
+    z-index: 10;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid rgb(0, 0, 0);
+  }
+
+  .popup-menu  h4{
+    margin: 0%;
+    padding: 0%;
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid black;
+    
+  }
+  
+  .popup-menu ul {
+    list-style-type: none;
+    /* background-color: aqua; */
+    margin: 0%;
+    padding: 0%;
+    cursor: pointer;
+    
+  }
+  .dropdown-item {
+    background-color: red;
+  }
+
+  .popup-menu li {
+    /* margin-bottom: 5px; */
+  }
+  
+  .popup-menu a {
+    text-decoration: none;
+    color: #333;
+  }
+  
+  .show {
+    display: block;
+   
+  }
+  
+
+
+body{ all: unset;}
+
+@font-face {
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Roboto Condensed'),
+        local('RobotoCondensed-Regular'),
+        url(.././fonts/roboto.woff2) format('woff2'),
+        url(.././fonts/roboto.woff) format('woff');
+  }

--- a/samples/cakeshop/css/style.css
+++ b/samples/cakeshop/css/style.css
@@ -8,12 +8,29 @@
   	url(../fonts/roboto.woff) format('woff');
 }
 
+  
+  /* Dark theme styles */
+.dark-theme {
+	--primary-color: #333;
+	--secondary-color: #555;
+	--text-color: #fff;
+  }
+  
+  /* Light theme styles */
+.light-theme {
+	--primary-color: #fff;
+	--secondary-color: #ddd;
+	--text-color: #333;
+  }
+  
+
 * {
 	box-sizing: border-box;
 }
 
 body {
-	background: #f0f0f0;
+	background-color:  var(--primary-color);
+	/* background: #f0f0f0; */
 	line-height: normal;
 	font-size: 16px;
 	overflow-Y: scroll;
@@ -21,8 +38,28 @@ body {
 	-webkit-font-smoothing: antialiased !important;
 }
 
+.navbar-container {
+	border: none; /* Remove the border */
+	display: block; /* Make the iframe a block-level element */
+	width: 100%; /* Adjust the width as needed */
+	height: 100%; /* Adjust the height as needed */
+	position: fixed;
+	top: 0%;
+	left: 0%;
+	z-index: 10000;
+}
+
+iframe {
+	
+}
+
+
 a, a:hover, a:visited, a:link, a:active {
 	text-decoration: none;
+}
+
+a:hover {
+	
 }
 
 a:active {
@@ -48,9 +85,11 @@ a:active {
 
 .settings {
     right: 25px;
-    position: absolute;
-    bottom: 26px;
+    /* position: absolute; */
+    /* bottom: 26px; */
     font-size: 20px;
+	/* background-color: red; */
+	
 }
 
 .settings:hover {
@@ -79,8 +118,23 @@ a:active {
 .dropdown-menu {
     border-radius: 0px;
     margin-top: 8px;
+	background-color: var(--secondary-color);
+	box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;
 }
-
+.dark-icon {
+	color: #333; /* Dark color of your choice */
+}
+.theme-class {
+	cursor: pointer;
+}
+.settings-icons   {
+    display: flex;
+	width: max-content;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	width: 95px;
+}
 .dropdown-arrow {
     height: 5px;
     background-color: #333;
@@ -101,6 +155,7 @@ a:active {
 
 .tower-page-title {
 	margin-bottom: 20px;
+	color: green;
 }
 
 .tower-page-title span {
@@ -110,15 +165,22 @@ a:active {
 }
 
 .tower-navigation {
+	
 	position: fixed;
 	left: 0;
 	right: 0;
 	top: 0;
 	box-shadow: 0 0px 9px 4px rgba(0, 0, 0, 0.1), 0 -5px 2px 2px
 		rgba(0, 0, 0, 0.1);
-	background: white;
-	z-index: 10000;
+	z-index: 9999;
+	height: 80px;
 	text-align: center;
+	display: flex;
+	align-items: center;
+	flex-direction: row;
+	justify-content: space-between;
+	background-color: var(--secondary-color);
+	color: var(--text-color);
 }
 
 .tower-navigation ul {
@@ -168,13 +230,13 @@ a:active {
 	color: #c6c6c6;
 }
 
-.tower-logo-container {
-	/*width: 225px;*/
-	text-align: center;
-	height: 50px;
-	float: left;
-	-webkit-transition: all .2s ease-in-out;
-	transition: all .2s ease-in-out;
+.tower-logo-container { 
+	/*width: 225px;*/ 
+	text-align: center;  
+	float: left; 
+	-webkit-transition: all .2s ease-in-out; 
+	transition: all .2s ease-in-out; 
+	background-color: transparent; 
 }
 
 .tower-toggle-btn, .tower-logo {
@@ -187,8 +249,15 @@ a:active {
 	font-weight: 900;
 	text-transform: uppercase;
 	text-decoration: none;
-	color: #222533;
+	/* color: #222533; */
 	display: inline-block;
+	overflow: hidden;
+	height: 50px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: max-content;
+	background-color: var(--secondary-color);
+	color: var(--text-color);
 }
 
 .tower-logo i {
@@ -226,15 +295,17 @@ a:active {
 	z-index: 9999;
 	position: fixed;
 	font-weight: 600;
-	background: white !important;
+	/* background: white !important; */
 	width: 225px;
 	height: 100vh;
-	top: 50px;
+	top: 80px;
 	left: 0;
 	bottom: 0;
 	box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 2px 4px 8px rgba(0, 0, 0, 0.28);
 	-webkit-transition: all .2s ease-in-out;
 	transition: all .2s ease-in-out;
+	background-color: var(--secondary-color);
+	color: var(--text-color);
 }
 
 .tower-sidebar li {
@@ -249,7 +320,8 @@ a:active {
 .tower-sidebar li a {
 	text-decoration: none;
 	display: block;
-	color: #515d6e;
+	color: #008ffd;
+	font-weight: bold;
 }
 
 .tower-sidebar li a i {
@@ -278,6 +350,8 @@ a:active {
 
 .tower-sidebar li:hover, .tower-sidebar li.active {
 	background: #f2f2f2;
+	background-color: var(--primary-color);
+	color: var(--text-color);
 }
 
 .tower-sidebar li:hover .icon-bg, .tower-sidebar li.active .icon-bg {
@@ -429,7 +503,7 @@ a:active {
 .tower-body-wrapper {
 	position: absolute;
 	left: 230px;
-	top: 75px;
+	top: 100px;
 	width: auto;
 	right: 0;
 	-webkit-transition: all .2s ease-in-out;
@@ -458,9 +532,10 @@ a:active {
 	}
 }
 
-@media screen and (min-width: 850px) {
+/* @media screen and (min-width: 850px) {
 	.tower-logo-container {
 		height: 75px;
+		background-color: red;
 	}
 	.tower-logo-container .tower-logo {
 		line-height: 75px;
@@ -475,11 +550,13 @@ a:active {
 	.tower-body-wrapper {
 		top: 100px;
 	}
-}
+} */
+
 
 @media screen and (max-width: 850px) {
 	.tower-navigation {
-		height: 100px;
+		/* height: 100px; */
+		/* background-color: red; */
 	}
 	.tower-logo-container.tower-nav-min {
 		-webkit-transform: translate3d(0, 0, 0);
@@ -488,31 +565,40 @@ a:active {
 	}
 	.tower-logo-container.tower-nav-min .tower-logo {
 		opacity: 1;
+		
 	}
 	.tower-logo-container.tower-nav-min+.tower-logo-hidden {
 		display: none;
+
 	}
 	.tower-logo-container {
 		display: block;
 		float: none;
-		width: 100%;
-		border-bottom: 1px solid #F2F2F2;
+		width: max-content;
 	}
 	.tower-sidebar {
-		top: 100px;
+		/* top: 100px; */
 	}
 	.tower-sidebar.tower-nav-min {
 		-webkit-transform: translate3d(-200px, 0, 0);
 		transform: translate3d(-200px, 0, 0);
 	}
 	.tower-body-wrapper {
-		top: 125px;
+		/* top: 125px; */
 		position: relative;
 	}
 	.tower-body-wrapper.tower-nav-min {
 		left: 0px;
 	}
+	.tower-toggle-btn, .tower-logo {
+		width: 210px;
+		font-size: 18px;
+		font-weight: 900;
+	}
 }
+
+
+
 
 .panel {
 	box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
@@ -751,3 +837,4 @@ pre {
 .controls-container i {
 	padding-right: 5px;
 }
+

--- a/samples/cakeshop/index.html
+++ b/samples/cakeshop/index.html
@@ -13,35 +13,37 @@
 	<link rel="stylesheet" type="text/css" href="css/epoch.min.css">
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<script type="text/javascript" src="js/index-gen.js"></script>
+	<script type="text/javascript" src="js/toggle-theme.js" defer></script>
 </head>
 
-<body>
-
-	<section>
+<body onload="onLoadTheme()">
 		<header>
 			<nav class="tower-navigation">
 				<div class="tower-logo-container">
 					<a href="#" class="tower-logo">Sample // Dashboard</a>
-					<!-- <a href="#" class="tower-toggle-btn pull-right"><i class="fa fa-bars"></i></a> -->
 				</div>
 				<a href="#" class="tower-logo-hidden">Tower Control</a>
-				<div class="dropdown settings">
-					<i class="fa fa-cog dropdown-toggle"  data-toggle="dropdown" aria-hidden="true" aria-haspopup="true" aria-expanded="false"></i>
-					<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-						<div class="dropdown-arrow"><div class="arrow-up"></div></div>
-						<ul>
-							<li class="dropdown-item" href="#"><h4>Settings</li></h4>
-							<hr />
-							<li id="reset" class="dropdown-item" href="#">Reset Layouts</li>
-						</ul>
+				<div class="settings-icons">
+					<div class="theme-class" id="toggle-theme-button" > <i class="fa fa-adjust"></i> </div>
+					<div class="dropdown settings">
+						<i class="fa fa-cog dropdown-toggle"  data-toggle="dropdown" aria-hidden="true" aria-haspopup="true" aria-expanded="false"></i>
+						<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+							<div class="dropdown-arrow"><div class="arrow-up"></div></div>
+							<ul>
+								<li class="dropdown-item" href="#"><h4>Settings</li></h4>
+								<hr />
+								<li id="reset" class="dropdown-item" href="#">Reset Layouts</li>
+							</ul>	
+						</div>
 					</div>
 				</div>
+				
 			</nav>
 		</header>
-	</section>
 
 	<aside>
 		<nav class="tower-sidebar">
+			
 			<ul>
 				<li id="console">
 					<a href="#" class="inbox">
@@ -75,12 +77,5 @@
 			</div>
 		</section>
 	</main>
-
-
-	<p style="width: 1px; height: 1px;">
-		<input type="text" id="_clipboard"/>
-		<button id="_clipboard_button" data-copytarget="#_clipboard">copy</button>
-	</p>
 </body>
-
 </html>

--- a/samples/cakeshop/js/toggle-theme.js
+++ b/samples/cakeshop/js/toggle-theme.js
@@ -1,0 +1,19 @@
+const button = document.getElementById('toggle-theme-button');
+
+button.addEventListener('click', toggleTheme);
+
+function toggleTheme () {
+       var lightTheme = 'light-theme';
+       var darkTheme = 'dark-theme';
+       var currentTheme = localStorage.getItem('theme');
+       if ( currentTheme === lightTheme)  { document.body.className = darkTheme; localStorage.setItem('theme',darkTheme) }
+       else { document.body.className= lightTheme; localStorage.setItem('theme',lightTheme) }
+   }
+ 
+function onLoadTheme () {
+    var lightTheme = 'light-theme';
+    var darkTheme = 'dark-theme';
+    var currentTheme = localStorage.getItem('theme');
+    if ( currentTheme === lightTheme)  { document.body.className = lightTheme; }
+    else { document.body.className= darkTheme; }
+}   


### PR DESCRIPTION
Fix responsive issue with navbar for screen sizes below 850px and add theme changing feature

The navbar was breaking when the screen size was smaller than 850px. This commit addresses the issue by applying responsive CSS rules to ensure the navbar remains intact on smaller screens.

In addition, this commit introduces a new feature to the site - the ability to change themes. Users can now switch between a dark theme and a light theme by clicking on the theme toggle button in the navigation menu. This enhances the user experience and provides more customization options.

BEFORE:

https://github.com/jpmorganchase/jif-dashboard/assets/90443391/03db1eb1-6524-4eb7-850d-eedf51fddc1a


AFTER:

https://github.com/jpmorganchase/jif-dashboard/assets/90443391/d4119228-92e8-4677-9119-32cff1fc6435



 
Fixes #2, Implements #9